### PR TITLE
Fix bug in TwoFactorAuthenticatorSignInAsync method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed a bug in the `TwoFactorAuthenticatorSignInAsync` method of the `SignInManager` facade where the claims of the user were not added to the token.
+
 ## [0.3.1] - 2024-08-13
 
 ### Fixed

--- a/Neolution.Extensions.Identity/TokenSignManager.cs
+++ b/Neolution.Extensions.Identity/TokenSignManager.cs
@@ -115,7 +115,7 @@
                 claims.Add(new Claim(ClaimTypes.AuthenticationMethod, authenticationMethod));
             }
 
-            return this.jwtGenerator.GenerateAccessToken(user, claims, "mfa");
+            return await this.CreateAccessTokenAsync(user, authenticationMethod);
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
Fixed a bug in the `TwoFactorAuthenticatorSignInAsync` method of the `SignInManager` facade where the claims of the user were not added to the token. This PR addresses the issue and ensures that the claims are properly added to the token.