### PR TITLE
Add ValidateIssuer parameter for flexible issuer validation in OpenIdConnectTokenValidationOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added `ValidateIssuer` parameter to the `OpenIdConnectTokenValidationOptions` to allow developers to disable issuer validation. Useful for example when allow multiple tenants to sign in via MS Entra.
+
 ## [0.4.0] - 2024-08-19
 
 ### Changed

--- a/Neolution.Extensions.Identity.Abstractions/OpenIdConnect/OpenIdConnectTokenValidationOptions.cs
+++ b/Neolution.Extensions.Identity.Abstractions/OpenIdConnect/OpenIdConnectTokenValidationOptions.cs
@@ -18,7 +18,7 @@
         /// <summary>
         /// Gets or sets the issuer.
         /// </summary>
-        public required string Issuer { get; set; }
+        public string Issuer { get; set; } = string.Empty;
 
         /// <summary>
         /// Gets or sets a value indicating whether to validate the issuer.

--- a/Neolution.Extensions.Identity.Abstractions/OpenIdConnect/OpenIdConnectTokenValidationOptions.cs
+++ b/Neolution.Extensions.Identity.Abstractions/OpenIdConnect/OpenIdConnectTokenValidationOptions.cs
@@ -19,5 +19,10 @@
         /// Gets or sets the issuer.
         /// </summary>
         public required string Issuer { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to validate the issuer.
+        /// </summary>
+        public bool ValidateIssuer { get; set; } = true;
     }
 }

--- a/Neolution.Extensions.Identity/TokenSignManager.cs
+++ b/Neolution.Extensions.Identity/TokenSignManager.cs
@@ -199,6 +199,7 @@
                 ValidAudience = token.ValidationOptions.ClientId,
                 ValidIssuer = token.ValidationOptions.Issuer,
                 IssuerSigningKeys = signingKeys,
+                ValidateIssuer = token.ValidationOptions.ValidateIssuer,
 
                 // Additional validation parameters as necessary
             };


### PR DESCRIPTION
Introduce the `ValidateIssuer` parameter to allow developers to control issuer validation, facilitating scenarios such as multi-tenant authentication.